### PR TITLE
Add TWZRD Agent Intel MCP server to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ __________                 ___________           .__           .____    .__     
 - [OpenZeppelin - Contracts / Test Helpers + More ](https://github.com/OpenZeppelin)
 - [Tudelft Repo](https://repository.tudelft.nl)
 - [Slitherin: Slither Detectors by Pessimistic.io](https://github.com/pessimistic-io/slitherin)
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust-scoring MCP server for x402 agents on Solana. Free on-chain preflight checks trust + identity signals; signed trust receipt via USDC micropayment (<$0.01, <1s settlement).
 
 ## Developer Tools 
 
@@ -455,6 +456,7 @@ __________                 ___________           .__           .____    .__     
 - [Spend Gas Stats](https://txn.finance) 
 - [Pools Stats](https://pools.fyi)
 - [Slitherin: Slither Detectors by Pessimistic.io](https://github.com/pessimistic-io/slitherin)
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust-scoring MCP server for x402 agents on Solana. Free on-chain preflight checks trust + identity signals; signed trust receipt via USDC micropayment (<$0.01, <1s settlement).
 
 ## NFTs
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Developer Tools** section.

**What is it**: Trust-scoring MCP server for x402 agents on Solana.
- **Free preflight**: On-chain checks for wallet trust + identity signals  
- **Paid receipt**: Signed USDC trust receipt (<$0.01, <1s settlement)
- **MCP URL**: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP)

Useful for DeFi researchers and developers building autonomous agents that need verifiable on-chain trust signals.